### PR TITLE
Fix guessing blank table immediately after guessing

### DIFF
--- a/app/static/js/init.js
+++ b/app/static/js/init.js
@@ -149,6 +149,7 @@ function addNewCraftingTable() {
   slot.appendChild(imageDiv);
 
   slot.addEventListener("mousedown", (e) => {
+    checkSolution();
     if (!isTableValid) return;
 
     let { isCorrect, matchmap } = processGuess(craftingTables[tableNum]);
@@ -250,7 +251,7 @@ function addNewCraftingTable() {
   });
   outputDiv.appendChild(slot);
 
-  // Helper function - called after placing item(s)
+  // Helper function - called after placing item(s) or clicking the solution slot
   const checkSolution = () => {
     let checkArrangementData = checkArrangement(craftingTables[tableNum]);
     if (checkArrangementData[0]) {


### PR DESCRIPTION
Visual of the bug:
![image](https://github.com/pavo-etc/minecraftle/assets/53013571/6b5520f2-f9c7-4262-945f-95c09a59737f)


Table validity is checked only when an item is placed on the crafting bench. This is fine for the first guess, because the table validity is false by default. However, after guessing validly and creating a new guessing table, the table validity isn't reset to false. This means the player can keep "guessing" (by clicking the crafting-output box) as long as they don't trigger the check by adding any items to the table.

Fixed by adding a validity check whenever the crafting output box is clicked before processing the guess.