### PR TITLE
fix: max guess limit and guess count display

### DIFF
--- a/app/static/js/init.js
+++ b/app/static/js/init.js
@@ -74,13 +74,6 @@ function setCursor(item) {
 }
 
 /**
- * Updates remaining guesses
- */
-function updateRemainingGuesses() {
-  document.getElementById("guess-counter").innerText = guessCount + 1;
-}
-
-/**
  * Create ingredients table from list.  Attaches event listeners to slots.
  */
 function initIngredients() {
@@ -207,7 +200,7 @@ function addNewCraftingTable() {
       setTimeout(() => {
         winner();
       }, 750);
-    } else if (guessCount <= maxGuesses) {
+    } else if (guessCount < maxGuesses) {
       for (const [rowNum, rowElements] of matchmap.entries()) {
         for (let i = 0; i < 3; i++) {
           if (rowNum === 1) {
@@ -240,14 +233,12 @@ function addNewCraftingTable() {
     solutiondiv.classList.add("lockedslot");
     solutiondiv.classList.remove("slot");
     solutiondiv.replaceWith(solutiondiv.cloneNode(true));
-    if (guessCount > maxGuesses) {
+
+    if (!isCorrect && (guessCount >= maxGuesses)) {
       setTimeout(() => {
         loser();
       }, 750);
-      return;
     }
-
-    updateRemainingGuesses();
   });
   outputDiv.appendChild(slot);
 

--- a/app/static/js/processGuess.js
+++ b/app/static/js/processGuess.js
@@ -311,7 +311,17 @@ function processGuess(guess) {
 
   addOrangeSlots(guess, correctSlots);
 
+  // only needs to progress to the next guess if the game is not over
+  // if guessCount reaches maxGuesses, the game is over
+  let currentGuessNumber = min(guessCount + 1, maxGuesses);
+  document.getElementById("guess-counter").innerText = currentGuessNumber;
+
   return { isCorrect: false, matchmap: correctSlots };
+}
+
+function min(a, b) {
+  if (a < b) return a;
+  return b;
 }
 
 function checkArrangement(table) {

--- a/app/static/js/processGuess.js
+++ b/app/static/js/processGuess.js
@@ -313,15 +313,10 @@ function processGuess(guess) {
 
   // only needs to progress to the next guess if the game is not over
   // if guessCount reaches maxGuesses, the game is over
-  let currentGuessNumber = min(guessCount + 1, maxGuesses);
+  let currentGuessNumber = Math.min(guessCount + 1, maxGuesses);
   document.getElementById("guess-counter").innerText = currentGuessNumber;
 
   return { isCorrect: false, matchmap: correctSlots };
-}
-
-function min(a, b) {
-  if (a < b) return a;
-  return b;
 }
 
 function checkArrangement(table) {


### PR DESCRIPTION
Fixes #18 

Limits the total amount of guesses to 10, as it should
Adds a catch to ensure the lose message does not show up if the game is won on the same turn the guess limit is reached
Limits updating the "guess-counter" div when the player has won; there is no additional increment in the guess count to display